### PR TITLE
Change metrics interface to provide Scope

### DIFF
--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -44,6 +44,7 @@ var (
 )
 
 // ScopeInit interface provides necessary data to properly initialize root metrics scope
+// service.Host conforms to this, but can't be used directly since it causes an import cycle
 type ScopeInit interface {
 	Name() string
 	Config() config.ConfigurationProvider

--- a/service/service.go
+++ b/service/service.go
@@ -121,14 +121,11 @@ func New(options ...Option) (Owner, error) {
 
 	// Initialize metrics. If no metrics reporters were Registered, do noop
 	// TODO(glib): add a logging reporter and use it by default, rather than noop
-	// TODO: read metrics tags from config
 	if svc.Metrics() == nil {
-		reporter := metrics.Reporter(cfg)
+		svc.scope = metrics.RootScope(svc)
 
-		if reporter != nil {
-			svc.scope = tally.NewRootScope("", nil, reporter, metrics.DefaultReporterInterval)
-		} else {
-			svc.scope = tally.NewRootScope("", nil, tally.NullStatsReporter, 0)
+		if svc.scope == nil {
+			svc.scope = tally.NoopScope
 		}
 
 		metrics.Freeze()


### PR DESCRIPTION
Allows for more flexibility of creating a root scope and a reporter in one place.