### PR TITLE
Use service WithConfiguration to not rely on global setup

### DIFF
--- a/.build/lint.mk
+++ b/.build/lint.mk
@@ -10,7 +10,7 @@ LINT_LOG := lint.log
 _THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 _THIS_DIR := $(dir $(_THIS_MAKEFILE))
 
-ERRCHECK_FLAGS := -ignorepkg example -ignore "fmt.*,io:WriteString"
+ERRCHECK_FLAGS := -ignorepkg example -ignore "fmt.*,io:WriteString" -ignoretests
 
 .PHONY: lint
 lint:

--- a/core/testutils/config.go
+++ b/core/testutils/config.go
@@ -26,8 +26,13 @@ import (
 	"go.uber.org/fx/core/config"
 )
 
-// WithConfig sets a global config and returns a function to defer reset
-func WithConfig(applicationID *string) func() {
+// StaticAppData creates a ConfigurationProvider for a valid appID/owner
+func StaticAppData(applicationID *string) config.ConfigurationProvider {
+	data := makeValidData(applicationID)
+	return config.NewStaticProvider(data)
+}
+
+func makeValidData(applicationID *string) map[string]interface{} {
 	if applicationID == nil {
 		_appID := "test" + randStringBytes(10)
 		applicationID = &_appID
@@ -38,13 +43,7 @@ func WithConfig(applicationID *string) func() {
 		"applicationID":    *applicationID,
 		"applicationOwner": applicationOwner,
 	}
-
-	oldProviders := config.Providers()
-	config.UnregisterProviders()
-	config.RegisterProviders(config.StaticProvider(data))
-	return func() {
-		config.RegisterProviders(oldProviders...)
-	}
+	return data
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -40,15 +40,12 @@ import (
 )
 
 func TestNew_OK(t *testing.T) {
-	defer WithConfig(nil)()
-	WithService(New(registerNothing), nil, func(s service.Owner) {
+	WithService(New(registerNothing), nil, []service.Option{configOption()}, func(s service.Owner) {
 		assert.NotNil(t, s, "Should create a module")
 	})
 }
 
 func TestNew_WithOptions(t *testing.T) {
-	defer WithConfig(nil)()
-
 	options := []modules.Option{
 		modules.WithRoles("testing"),
 	}
@@ -127,6 +124,10 @@ func TestHookupOptions_Error(t *testing.T) {
 
 // TODO(ai) add a test for binding a bad port and get an error out of Start()
 
+func configOption() service.Option {
+	return service.WithConfiguration(StaticAppData(nil))
+}
+
 func withModule(
 	t testing.TB,
 	hookup CreateHTTPRegistrantsFunc,
@@ -134,7 +135,6 @@ func withModule(
 	expectError bool,
 	fn func(*Module),
 ) {
-	defer WithConfig(nil)()
 	mi := service.ModuleCreateInfo{
 		Host: service.NullHost(),
 	}

--- a/service/builder.go
+++ b/service/builder.go
@@ -28,11 +28,8 @@ type Builder struct {
 
 // NewBuilder returns a new Builder for instantiating services
 func NewBuilder(options ...Option) *Builder {
-	b := &Builder{
-		options: options,
-	}
-
-	return b
+	b := &Builder{}
+	return b.WithOptions(options...)
 }
 
 // WithModules adds the given modules to the service
@@ -46,6 +43,12 @@ func (b *Builder) WithModules(modules ...ModuleCreateFunc) *Builder {
 func WithModules(modules ...ModuleCreateFunc) *Builder {
 	b := NewBuilder()
 	return b.WithModules(modules...)
+}
+
+// WithOptions adds service Options to the builder
+func (b *Builder) WithOptions(options ...Option) *Builder {
+	b.options = append(b.options, options...)
+	return b
 }
 
 // Build returns the service, or any errors encountered during build phase.

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -36,9 +36,9 @@ func TestNewBuilder_NoConfig(t *testing.T) {
 }
 
 func TestNewBuilder_WithConfig(t *testing.T) {
-	defer WithConfig(nil)()
-
-	b := NewBuilder()
+	b := NewBuilder(
+		WithConfiguration(StaticAppData(nil)),
+	)
 
 	svc, err := b.Build()
 	require.NoError(t, err)
@@ -46,31 +46,32 @@ func TestNewBuilder_WithConfig(t *testing.T) {
 }
 
 func TestBuilder_WithModules(t *testing.T) {
-	defer WithConfig(nil)()
-
-	_, err := NewBuilder().WithModules(noopModule).Build()
+	_, err := NewBuilder(
+		WithConfiguration(StaticAppData(nil)),
+	).WithModules(noopModule).Build()
 	assert.NoError(t, err)
 }
 
 func TestBuilder_WithErrModule(t *testing.T) {
-	defer WithConfig(nil)()
-
-	_, err := NewBuilder().WithModules(errModule).Build()
+	_, err := NewBuilder(
+		WithConfiguration(StaticAppData(nil)),
+	).WithModules(errModule).Build()
 	assert.Error(t, err)
 }
 
 func TestBuilder_SkipsModulesBadInit(t *testing.T) {
 	empty := ""
-	defer WithConfig(&empty)()
 
-	_, err := NewBuilder().WithModules(noopModule).Build()
+	_, err := NewBuilder(
+		WithConfiguration(StaticAppData(&empty)),
+	).WithModules(noopModule).Build()
 	assert.Error(t, err)
 }
 
 func TestWithModules_OK(t *testing.T) {
-	defer WithConfig(nil)()
-
-	_, err := WithModules(noopModule).Build()
+	_, err := WithModules(noopModule).WithOptions(
+		WithConfiguration(StaticAppData(nil)),
+	).Build()
 	assert.NoError(t, err)
 }
 

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/fx/core/ulog"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,6 +39,13 @@ func TestAddModules_OK(t *testing.T) {
 func TestAddModules_Errors(t *testing.T) {
 	sh := &host{}
 	assert.Error(t, sh.AddModules(errorModuleCreate))
+}
+
+func TestWithLogger_OK(t *testing.T) {
+	logger := ulog.Logger()
+	assert.NotPanics(t, func() {
+		New(WithLogger(logger))
+	})
 }
 
 func successModuleCreate(_ ModuleCreateInfo) ([]Module, error) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -77,11 +77,11 @@ func newTestStatsReporter() *testStatsReporter {
 }
 
 func TestServiceCreation(t *testing.T) {
-	defer withConfigData(validServiceConfig)()
 	r := newTestStatsReporter()
 	r.cw.Add(1)
 	scope := tally.NewRootScope("", nil, r, 50*time.Millisecond)
 	svc, err := New(
+		withConfigOption(validServiceConfig),
 		WithMetricsRootScope(scope),
 	)
 	require.NoError(t, err)
@@ -92,8 +92,8 @@ func TestServiceCreation(t *testing.T) {
 }
 
 func TestWithObserver_Nil(t *testing.T) {
-	defer withConfigData(validServiceConfig)()
 	svc, err := New(
+		withConfigOption(validServiceConfig),
 		WithObserver(nil),
 	)
 	require.NoError(t, err)
@@ -102,33 +102,32 @@ func TestWithObserver_Nil(t *testing.T) {
 }
 
 func TestServiceCreation_MissingRequiredParams(t *testing.T) {
-	defer withConfigData(nil)()
-	_, err := New()
+	_, err := New(withConfigOption(nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "zero value")
 }
 
 func TestServiceWithRoles(t *testing.T) {
-	defer withConfigData(map[string]interface{}{
+	data := map[string]interface{}{
 		"applicationID":    "name",
 		"applicationOwner": "owner",
 		"roles.0":          "foo",
-	})()
+	}
+	cfgOpt := withConfigOption(data)
 
-	svc, err := New()
+	svc, err := New(cfgOpt)
 	require.NoError(t, err)
 
 	assert.Contains(t, svc.Roles(), "foo")
 }
 
 func TestBadOption_Panics(t *testing.T) {
-	defer withConfigData(validServiceConfig)()
 	opt := func(_ Host) error {
 		return errors.New("nope")
 	}
 
 	assert.Panics(t, func() {
-		_, err := New(opt)
+		_, err := New(withConfigOption(validServiceConfig), opt)
 		if err != nil {
 			assert.Fail(t, "should not reach this path")
 		}
@@ -136,9 +135,8 @@ func TestBadOption_Panics(t *testing.T) {
 }
 
 func TestNew_WithObserver(t *testing.T) {
-	defer withConfigData(validServiceConfig)()
 	o := observerStub()
-	svc, err := New(WithObserver(o))
+	svc, err := New(withConfigOption(validServiceConfig), WithObserver(o))
 	require.NoError(t, err)
 	assert.Equal(t, o, svc.Observer())
 }
@@ -148,12 +146,6 @@ var validServiceConfig = map[string]interface{}{
 	"applicationOwner": "go.uber.org/fx",
 }
 
-// withConfigData sets a global config and returns a function to defer reset
-func withConfigData(data map[string]interface{}) func() {
-	oldProviders := config.Providers()
-	config.UnregisterProviders()
-	config.RegisterProviders(config.StaticProvider(data))
-	return func() {
-		config.RegisterProviders(oldProviders...)
-	}
+func withConfigOption(data map[string]interface{}) Option {
+	return WithConfiguration(config.NewStaticProvider(data))
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -81,7 +81,7 @@ func TestServiceCreation(t *testing.T) {
 	r.cw.Add(1)
 	scope := tally.NewRootScope("", nil, r, 50*time.Millisecond)
 	svc, err := New(
-		withConfigOption(validServiceConfig),
+		withConfig(validServiceConfig),
 		WithMetricsRootScope(scope),
 	)
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestServiceCreation(t *testing.T) {
 
 func TestWithObserver_Nil(t *testing.T) {
 	svc, err := New(
-		withConfigOption(validServiceConfig),
+		withConfig(validServiceConfig),
 		WithObserver(nil),
 	)
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestWithObserver_Nil(t *testing.T) {
 }
 
 func TestServiceCreation_MissingRequiredParams(t *testing.T) {
-	_, err := New(withConfigOption(nil))
+	_, err := New(withConfig(nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "zero value")
 }
@@ -113,7 +113,7 @@ func TestServiceWithRoles(t *testing.T) {
 		"applicationOwner": "owner",
 		"roles.0":          "foo",
 	}
-	cfgOpt := withConfigOption(data)
+	cfgOpt := withConfig(data)
 
 	svc, err := New(cfgOpt)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestBadOption_Panics(t *testing.T) {
 	}
 
 	assert.Panics(t, func() {
-		_, err := New(withConfigOption(validServiceConfig), opt)
+		_, err := New(withConfig(validServiceConfig), opt)
 		if err != nil {
 			assert.Fail(t, "should not reach this path")
 		}
@@ -136,7 +136,7 @@ func TestBadOption_Panics(t *testing.T) {
 
 func TestNew_WithObserver(t *testing.T) {
 	o := observerStub()
-	svc, err := New(withConfigOption(validServiceConfig), WithObserver(o))
+	svc, err := New(withConfig(validServiceConfig), WithObserver(o))
 	require.NoError(t, err)
 	assert.Equal(t, o, svc.Observer())
 }
@@ -146,6 +146,6 @@ var validServiceConfig = map[string]interface{}{
 	"applicationOwner": "go.uber.org/fx",
 }
 
-func withConfigOption(data map[string]interface{}) Option {
+func withConfig(data map[string]interface{}) Option {
 	return WithConfiguration(config.NewStaticProvider(data))
 }

--- a/service/testutils/service.go
+++ b/service/testutils/service.go
@@ -23,12 +23,7 @@ package testutils
 import "go.uber.org/fx/service"
 
 // WithService is a test helper to instantiate a service
-func WithService(module service.ModuleCreateFunc, instance service.Observer, options []service.Option, fn func(service.Owner)) {
-	WithServices([]service.ModuleCreateFunc{module}, instance, options, fn)
-}
-
-// WithServices is a test helper to instantiate a service with multiple modules
-func WithServices(modules []service.ModuleCreateFunc, observer service.Observer, options []service.Option, fn func(service.Owner)) {
+func WithService(module service.ModuleCreateFunc, observer service.Observer, options []service.Option, fn func(service.Owner)) {
 	if observer == nil {
 		observer = service.ObserverStub()
 	}
@@ -37,7 +32,7 @@ func WithServices(modules []service.ModuleCreateFunc, observer service.Observer,
 	if err != nil {
 		panic(err)
 	}
-	err = svc.AddModules(modules...)
+	err = svc.AddModules(module)
 
 	if err != nil {
 		panic(err)

--- a/service/testutils/service.go
+++ b/service/testutils/service.go
@@ -23,17 +23,17 @@ package testutils
 import "go.uber.org/fx/service"
 
 // WithService is a test helper to instantiate a service
-func WithService(module service.ModuleCreateFunc, instance service.Observer, fn func(service.Owner)) {
-	WithServices([]service.ModuleCreateFunc{module}, instance, fn)
+func WithService(module service.ModuleCreateFunc, instance service.Observer, options []service.Option, fn func(service.Owner)) {
+	WithServices([]service.ModuleCreateFunc{module}, instance, options, fn)
 }
 
 // WithServices is a test helper to instantiate a service with multiple modules
-func WithServices(modules []service.ModuleCreateFunc, observer service.Observer, fn func(service.Owner)) {
+func WithServices(modules []service.ModuleCreateFunc, observer service.Observer, options []service.Option, fn func(service.Owner)) {
 	if observer == nil {
 		observer = service.ObserverStub()
 	}
 
-	svc, err := service.New(service.WithObserver(observer))
+	svc, err := service.New(append(options, service.WithObserver(observer))...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Again trying to move away from modifying global state in tests.

Use the WithConfiguration() option to set a configuration provider.