### PR TITLE
Revert DynamicProviderfunc change

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -110,7 +110,7 @@ func GetEnvironmentPrefix() string {
 type ProviderFunc func() (ConfigurationProvider, error)
 
 // DynamicProviderFunc is used to create config providers on configuration initialization
-type DynamicProviderFunc func(serviceName string, config ConfigurationProvider) (ConfigurationProvider, error)
+type DynamicProviderFunc func(config ConfigurationProvider) (ConfigurationProvider, error)
 
 // RegisterProviders registers configuration providers for the global config
 func RegisterProviders(providerFuncs ...ProviderFunc) {
@@ -151,17 +151,9 @@ func Load() ConfigurationProvider {
 		static = append(static, cp)
 	}
 	baseCfg := NewProviderGroup("global", static...)
-
-	// TODO: (at) If application ID is not specified, the code lets the service initialization
-	// handle the failures and skips initializing dynamic config.
-	serviceName, ok := baseCfg.GetValue("applicationID").TryAsString()
-	if !ok {
-		return baseCfg
-	}
 	var dynamic []ConfigurationProvider
-
 	for _, providerFunc := range _dynamicProviderFuncs {
-		cp, err := providerFunc(serviceName, baseCfg)
+		cp, err := providerFunc(baseCfg)
 		if err != nil {
 			panic(err)
 		}

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -265,10 +265,9 @@ boolean:
 
 func TestRegisteredProvidersInitialization(t *testing.T) {
 	RegisterProviders(StaticProvider(map[string]interface{}{
-		"hello":         "world",
-		"applicationID": "test",
+		"hello": "world",
 	}))
-	RegisterDynamicProviders(func(serviceName string, dynamic ConfigurationProvider) (ConfigurationProvider, error) {
+	RegisterDynamicProviders(func(dynamic ConfigurationProvider) (ConfigurationProvider, error) {
 		return NewStaticProvider(map[string]interface{}{
 			"dynamic": "provider",
 		}), nil


### PR DESCRIPTION
Reverting PR - https://github.com/uber-go/uberfx/pull/15

Moving this fetch downstreams and letting the dynamic provider initializers handle the serviceName from baseCfg.