### PR TITLE
Fix unregister providers for dynamic provider

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -138,6 +138,7 @@ func UnregisterProviders() {
 	_setupMux.Lock()
 	defer _setupMux.Unlock()
 	_staticProviderFuncs = nil
+	_dynamicProviderFuncs = nil
 }
 
 // Load creates a ConfigurationProvider for use in a service

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -276,6 +276,9 @@ func TestRegisteredProvidersInitialization(t *testing.T) {
 	assert.Equal(t, "global", cfg.Name())
 	assert.Equal(t, "world", cfg.GetValue("hello").AsString())
 	assert.Equal(t, "provider", cfg.GetValue("dynamic").AsString())
+	UnregisterProviders()
+	assert.Nil(t, _staticProviderFuncs)
+	assert.Nil(t, _dynamicProviderFuncs)
 }
 
 func TestNilProvider(t *testing.T) {


### PR DESCRIPTION
We were not performing Unregister on dynamicProviderFuncs causing issues in tests.  