### PR TITLE
Close tally scopes on service stop

### DIFF
--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -51,7 +51,7 @@ type ScopeInit interface {
 }
 
 // ScopeFunc is used during service init time to register the reporter
-type ScopeFunc func(i ScopeInit) (tally.Scope, error)
+type ScopeFunc func(i ScopeInit) (tally.RootScope, error)
 
 // Freeze ensures that after servce is started, no other metrics manipulations can be done
 //
@@ -91,7 +91,7 @@ func RegisterRootScope(rep ScopeFunc) {
 }
 
 // RootScope returns the provided stats reporter, or nil
-func RootScope(i ScopeInit) tally.Scope {
+func RootScope(i ScopeInit) tally.RootScope {
 	_mu.Lock()
 	defer _mu.Unlock()
 

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -66,15 +66,15 @@ func TestRegisterBadReporterPanics(t *testing.T) {
 	})
 }
 
-func goodScope(i ScopeInit) (tally.Scope, error) {
+func goodScope(i ScopeInit) (tally.RootScope, error) {
 	return tally.NoopScope, nil
 }
 
-func badScope(i ScopeInit) (tally.Scope, error) {
+func badScope(i ScopeInit) (tally.RootScope, error) {
 	return nil, errors.New("fake error")
 }
 
-func getScope() tally.Scope {
+func getScope() tally.RootScope {
 	return RootScope(scopeInit())
 }
 

--- a/service/core.go
+++ b/service/core.go
@@ -65,7 +65,7 @@ type serviceCore struct {
 	state          State
 	configProvider config.ConfigurationProvider
 	scopeMux       sync.Mutex
-	scope          tally.Scope
+	scope          tally.RootScope
 	observer       Observer
 	items          map[string]interface{}
 	logConfig      ulog.Configuration

--- a/service/host.go
+++ b/service/host.go
@@ -142,6 +142,11 @@ func (s *host) shutdown(err error, reason string, exitCode *int) (bool, error) {
 		}
 	}
 
+	// Stop the metrics reporting
+	if s.scope != nil {
+		s.scope.Close()
+	}
+
 	// report that we shutdown.
 	s.closeChan <- *s.shutdownReason
 	close(s.closeChan)

--- a/service/host.go
+++ b/service/host.go
@@ -134,16 +134,13 @@ func (s *host) shutdown(err error, reason string, exitCode *int) (bool, error) {
 		s.shutdownReason.ExitCode = *exitCode
 	}
 
-	s.stopModules()
-
-	// TODO: What do we do with shutdown errors?
-	// if len(errs) > 0 {
-	// 	errList := "errModuleStopError\n"
-	// 	for k, v := range errs {
-	// 		errList += fmt.Sprintf("Module %q: %s\n", k.Name(), v.Error())
-	// 	}
-
-	// }
+	// Log the module shutdown errors
+	errs := s.stopModules()
+	if len(errs) > 0 {
+		for k, v := range errs {
+			ulog.Logger().Error("Failure to shut down module", "name", k.Name(), "error", v.Error())
+		}
+	}
 
 	// report that we shutdown.
 	s.closeChan <- *s.shutdownReason


### PR DESCRIPTION
Fix the root metrics scope to use the correct interface also (which is the one that has `Close()` method) and call it on shutdown.

GFM-96 #resolve