### PR TITLE
 Exclude nil providers from ProviderGroup

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -158,7 +158,6 @@ func Load() ConfigurationProvider {
 		if err != nil {
 			panic(err)
 		}
-		// We registered dynamic provider but chose not to initialize via configuration
 		if cp != nil {
 			dynamic = append(dynamic, cp)
 		}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -158,7 +158,10 @@ func Load() ConfigurationProvider {
 		if err != nil {
 			panic(err)
 		}
-		dynamic = append(dynamic, cp)
+		// We registered dynamic provider but chose not to initialize via configuration
+		if cp != nil {
+			dynamic = append(dynamic, cp)
+		}
 	}
 	return NewProviderGroup("global", append(static, dynamic...)...)
 }

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -286,16 +286,19 @@ func TestNilProvider(t *testing.T) {
 		return nil, fmt.Errorf("error creating Provider")
 	})
 	assert.Panics(t, func() { Load() }, "Can't initialize with nil provider")
-	UnregisterProviders()
 
-	RegisterProviders(func() (ConfigurationProvider, error) {
-		return nil, nil
-	})
-	Load()
 	oldProviders := _staticProviderFuncs
 	defer func() {
 		_staticProviderFuncs = oldProviders
 	}()
+
+	UnregisterProviders()
+	RegisterProviders(func() (ConfigurationProvider, error) {
+		return nil, nil
+	})
+	// don't panic on Load
+	Load()
+
 	UnregisterProviders()
 	assert.Nil(t, _staticProviderFuncs)
 }

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -286,6 +286,12 @@ func TestNilProvider(t *testing.T) {
 		return nil, fmt.Errorf("error creating Provider")
 	})
 	assert.Panics(t, func() { Load() }, "Can't initialize with nil provider")
+	UnregisterProviders()
+
+	RegisterProviders(func() (ConfigurationProvider, error) {
+		return nil, nil
+	})
+	Load()
 	oldProviders := _staticProviderFuncs
 	defer func() {
 		_staticProviderFuncs = oldProviders


### PR DESCRIPTION
GFM-59

Whenever dynamic providers are excluded via configuration, don't append to the provider group.