### PR TITLE
Initialize dynamic before append

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -152,7 +152,8 @@ func Load() ConfigurationProvider {
 		static = append(static, cp)
 	}
 	baseCfg := NewProviderGroup("global", static...)
-	var dynamic []ConfigurationProvider
+
+	var dynamic = make([]ConfigurationProvider, 0, 2)
 	for _, providerFunc := range _dynamicProviderFuncs {
 		cp, err := providerFunc(baseCfg)
 		if err != nil {


### PR DESCRIPTION
TIL appending empty slice to slice is ok, but appending uninitialized slice to slice results in <nil> append. 